### PR TITLE
test: add Cypress end-to-end test scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ build/
 
 ### Mac OS ###
 .DS_Store
+# Node
+node_modules/
+cypress/videos/
+cypress/screenshots/

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    fileServerFolder: '.',
+    supportFile: false,
+  },
+});

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,0 +1,6 @@
+describe('Hotel landing page', () => {
+  it('displays welcome message', () => {
+    cy.visit('/index.html');
+    cy.contains('h1', 'Hotel Surotec').should('be.visible');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hotel Surotec</title>
+</head>
+<body>
+  <h1>Hotel Surotec</h1>
+  <p>Bienvenido al sistema de reservas.</p>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hoteltesting",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "cypress run"
+  },
+  "devDependencies": {
+    "cypress": "^13.6.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal HTML landing page for testing
- configure Cypress with sample test asserting welcome message
- ignore Node and Cypress artifacts via .gitignore

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*
- `npm test` *(fails: cypress: not found)*
- `mvn -q test` *(fails: Network is unreachable when resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6897771958ec8327b42f337147146c3d