### PR TITLE
Add Cypress test scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+# Node
+node_modules/

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  e2e: {
+    supportFile: false
+  }
+};

--- a/cypress/e2e/servicioDemo.cy.js
+++ b/cypress/e2e/servicioDemo.cy.js
@@ -1,0 +1,18 @@
+describe('ServicioDemo', () => {
+  before(() => {
+    cy.exec('bash -lc "mkdir -p target/classes && javac $(find src/main/java -name \'*.java\') -d target/classes"');
+  });
+
+  it('manipula huespedes', () => {
+    cy.exec('java -cp target/classes servicios.ServicioDemo huesped').its('stdout')
+      .should('contain', 'Listado inicial: 1')
+      .and('contain', 'Buscar 1: Juan')
+      .and('contain', 'Listado final: 0');
+  });
+
+  it('manipula empleados', () => {
+    cy.exec('java -cp target/classes servicios.ServicioDemo empleado').its('stdout')
+      .should('contain', 'Buscar 1: Ana')
+      .and('contain', 'Cargo actualizado: Gerente');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hoteltesting",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "cypress run"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "cypress": "^13.7.0"
+  }
+}

--- a/src/main/java/servicios/EmpleadoServiceImpl.java
+++ b/src/main/java/servicios/EmpleadoServiceImpl.java
@@ -2,30 +2,39 @@ package servicios;
 
 import modelo.dominio.Persona;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EmpleadoServiceImpl implements PersonaInterface {
+
+    private final Map<Integer, Persona> personas = new HashMap<>();
 
     @Override
     public void registrarPersona(Persona persona) {
-
+        personas.put(persona.getId(), persona);
     }
 
     @Override
     public void eliminarPersona(int id) {
-
+        personas.remove(id);
     }
 
     @Override
     public Persona buscarPersona(int id) {
-        return null;
+        return personas.get(id);
     }
 
     @Override
     public void actualizarPersona(Persona persona) {
-
+        personas.put(persona.getId(), persona);
     }
 
     @Override
     public void listarPersonas() {
+        personas.values().forEach(System.out::println);
+    }
 
+    public int totalPersonas() {
+        return personas.size();
     }
 }

--- a/src/main/java/servicios/HuespedServiceImpl.java
+++ b/src/main/java/servicios/HuespedServiceImpl.java
@@ -2,31 +2,39 @@ package servicios;
 
 import modelo.dominio.Persona;
 
-public class HuespedServiceImpl implements PersonaInterface{
+import java.util.HashMap;
+import java.util.Map;
 
+public class HuespedServiceImpl implements PersonaInterface {
+
+    private final Map<Integer, Persona> personas = new HashMap<>();
 
     @Override
     public void registrarPersona(Persona persona) {
-
+        personas.put(persona.getId(), persona);
     }
 
     @Override
     public void eliminarPersona(int id) {
-
+        personas.remove(id);
     }
 
     @Override
     public Persona buscarPersona(int id) {
-        return null;
+        return personas.get(id);
     }
 
     @Override
     public void actualizarPersona(Persona persona) {
-
+        personas.put(persona.getId(), persona);
     }
 
     @Override
     public void listarPersonas() {
+        personas.values().forEach(System.out::println);
+    }
 
+    public int totalPersonas() {
+        return personas.size();
     }
 }

--- a/src/main/java/servicios/ServicioDemo.java
+++ b/src/main/java/servicios/ServicioDemo.java
@@ -1,0 +1,38 @@
+package servicios;
+
+import modelo.dominio.*;
+
+public class ServicioDemo {
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("Modo esperado: huesped o empleado");
+            return;
+        }
+
+        switch (args[0]) {
+            case "huesped" -> ejecutarHuespedDemo();
+            case "empleado" -> ejecutarEmpleadoDemo();
+            default -> System.err.println("Modo no valido: " + args[0]);
+        }
+    }
+
+    private static void ejecutarHuespedDemo() {
+        HuespedServiceImpl service = new HuespedServiceImpl();
+        service.registrarPersona(new Huesped(1, "Juan", "Perez", "123", "Calle 1", "Ingeniero", "Bogota", "VIP"));
+        System.out.println("Listado inicial: " + service.totalPersonas());
+        Persona encontrada = service.buscarPersona(1);
+        System.out.println("Buscar 1: " + (encontrada != null ? ((Huesped) encontrada).getNombre() : "null"));
+        service.eliminarPersona(1);
+        System.out.println("Listado final: " + service.totalPersonas());
+    }
+
+    private static void ejecutarEmpleadoDemo() {
+        EmpleadoServiceImpl service = new EmpleadoServiceImpl();
+        service.registrarPersona(new Empleado(1, "Ana", "Gomez", "555", "Calle 2", "Recepcionista"));
+        Persona encontrada = service.buscarPersona(1);
+        System.out.println("Buscar 1: " + (encontrada != null ? ((Empleado) encontrada).getNombre() : "null"));
+        service.actualizarPersona(new Empleado(1, "Ana", "Gomez", "555", "Calle 2", "Gerente"));
+        Empleado actualizado = (Empleado) service.buscarPersona(1);
+        System.out.println("Cargo actualizado: " + actualizado.getCargo());
+    }
+}


### PR DESCRIPTION
## Summary
- implement in-memory CRUD logic for guest and employee services
- add demo runner and Cypress spec invoking Java services via shell
- configure Node project with Cypress test script

## Testing
- `npm test` *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897798af81883279eed62602a4ea837